### PR TITLE
Add Ktor skeleton with health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# ride-hailing-app
+# Dispatch Service
+
+This project is a simple Kotlin application using Ktor. It includes Exposed for PostgreSQL access, HikariCP for connection pooling, and kotlinx serialization for JSON handling.
+
+Run the application with:
+
+```bash
+./gradlew run
+```
+
+Access the health check at `http://localhost:8080/health`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    kotlin("jvm") version "1.9.22"
+    application
+    kotlin("plugin.serialization") version "1.9.22"
+}
+
+application {
+    mainClass.set("com.dispatch.app.ApplicationKt")
+}
+
+repositories {
+    mavenCentral()
+}
+
+val ktorVersion = "2.3.9"
+val exposedVersion = "0.41.1"
+val logbackVersion = "1.4.11"
+val hikariVersion = "5.0.1"
+val postgresVersion = "42.6.0"
+
+dependencies {
+    implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion")
+    implementation("io.ktor:ktor-server-call-logging-jvm:$ktorVersion")
+
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
+    implementation("org.postgresql:postgresql:$postgresVersion")
+    implementation("com.zaxxer:HikariCP:$hikariVersion")
+
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
+
+    testImplementation(kotlin("test"))
+    testImplementation("io.ktor:ktor-server-tests-jvm:$ktorVersion")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "dispatch-service"

--- a/src/main/kotlin/com/dispatch/app/Application.kt
+++ b/src/main/kotlin/com/dispatch/app/Application.kt
@@ -1,0 +1,28 @@
+package com.dispatch.app
+
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.routing.routing
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.request.*
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+
+fun main() {
+    embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)
+}
+
+fun Application.module() {
+    install(ContentNegotiation) {
+        json()
+    }
+
+    routing {
+        get("/health") {
+            call.respond(HttpStatusCode.OK, mapOf("message" to "Dispatch Service is running"))
+        }
+    }
+}

--- a/src/test/kotlin/com/dispatch/app/ApplicationTest.kt
+++ b/src/test/kotlin/com/dispatch/app/ApplicationTest.kt
@@ -1,0 +1,17 @@
+package com.dispatch.app
+
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+
+class ApplicationTest {
+    @Test
+    fun testHealth() = testApplication {
+        val response = client.get("/health")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("{\"message\":\"Dispatch Service is running\"}", response.bodyAsText())
+    }
+}


### PR DESCRIPTION
## Summary
- create Gradle Kotlin build files
- implement a simple Ktor service
- expose health check at `/health`
- add a basic test and README update

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `gradle wrapper` *(fails to resolve Kotlin plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6850048708988321ac20eff1d6f245db