### PR TITLE
Fix compile errors in Ktor app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This project is a simple Kotlin application using Ktor. It includes Exposed for PostgreSQL access, HikariCP for connection pooling, and kotlinx serialization for JSON handling.
 
-Run the application with:
+Run the application with a local Gradle installation:
 
 ```bash
-./gradlew run
+gradle run
 ```
 
 Access the health check at `http://localhost:8080/health`.

--- a/src/main/kotlin/com/dispatch/app/Application.kt
+++ b/src/main/kotlin/com/dispatch/app/Application.kt
@@ -2,14 +2,13 @@ package com.dispatch.app
 
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import io.ktor.server.routing.routing
-import io.ktor.server.application.Application
-import io.ktor.server.application.call
-import io.ktor.server.response.respond
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.response.*
 import io.ktor.server.request.*
-import io.ktor.http.HttpStatusCode
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
+import io.ktor.http.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
 
 fun main() {
     embeddedServer(Netty, port = 8080, module = Application::module).start(wait = true)


### PR DESCRIPTION
## Summary
- fix imports in the Ktor Application file
- update README to use `gradle` instead of missing wrapper

## Testing
- `gradle test` *(fails: Plugin not found due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_68500a9c56d883218d587b9b2118da67