### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore Gradle build artifacts
+.gradle/
+build/
+# Ignore build directories in any submodules
+*/build/
+# IntelliJ project files
+.idea/
+*.iml
+out/
+# OS generated files
+.DS_Store
+# Log files
+*.log


### PR DESCRIPTION
## Summary
- ignore Gradle and IntelliJ files with a new `.gitignore`

## Testing
- `gradle test` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68500b5ecbdc8321bfda547f8d5ad88a