### PR TITLE
Add fare estimator service

### DIFF
--- a/src/main/kotlin/com/dispatch/app/FareEstimatorService.kt
+++ b/src/main/kotlin/com/dispatch/app/FareEstimatorService.kt
@@ -1,0 +1,61 @@
+package com.dispatch.app
+
+import kotlin.math.*
+
+enum class RideCategory {
+    GO,
+    SUV
+}
+
+data class FareEstimate(
+    val distanceInKm: Double,
+    val durationInMin: Double,
+    val baseFare: Double,
+    val distanceFare: Double,
+    val timeFare: Double,
+    val surgeMultiplier: Double,
+    val totalFare: Double
+)
+
+class FareEstimatorService {
+    fun estimateFare(
+        pickupLat: Double,
+        pickupLng: Double,
+        dropLat: Double,
+        dropLng: Double,
+        category: RideCategory
+    ): FareEstimate {
+        val distance = haversine(pickupLat, pickupLng, dropLat, dropLng)
+        val duration = distance * 2
+        val rates = when (category) {
+            RideCategory.GO -> Triple(50.0, 10.0, 2.0)
+            RideCategory.SUV -> Triple(100.0, 20.0, 4.0)
+        }
+        val (base, perKm, perMin) = rates
+        val distanceFare = perKm * distance
+        val timeFare = perMin * duration
+        val surgeMultiplier = 1.0
+        val total = (base + distanceFare + timeFare) * surgeMultiplier
+
+        return FareEstimate(
+            distanceInKm = distance,
+            durationInMin = duration,
+            baseFare = base,
+            distanceFare = distanceFare,
+            timeFare = timeFare,
+            surgeMultiplier = surgeMultiplier,
+            totalFare = total
+        )
+    }
+
+    private fun haversine(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val R = 6371.0
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+        val a = sin(dLat / 2).pow(2) +
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                sin(dLon / 2).pow(2)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return R * c
+    }
+}

--- a/src/test/kotlin/com/dispatch/app/FareEstimatorServiceTest.kt
+++ b/src/test/kotlin/com/dispatch/app/FareEstimatorServiceTest.kt
@@ -1,0 +1,42 @@
+package com.dispatch.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FareEstimatorServiceTest {
+    private val service = FareEstimatorService()
+
+    @Test
+    fun estimateFareGo() {
+        val result = service.estimateFare(
+            pickupLat = 12.9716,
+            pickupLng = 77.5946,
+            dropLat = 13.0827,
+            dropLng = 80.2707,
+            category = RideCategory.GO
+        )
+        val expectedDuration = result.distanceInKm * 2
+        val expectedTotal = 50.0 + 10.0 * result.distanceInKm + 2.0 * expectedDuration
+        assertEquals(50.0, result.baseFare)
+        assertEquals(expectedDuration, result.durationInMin, 0.0001)
+        assertEquals(expectedTotal, result.totalFare, 0.01)
+        assertEquals(1.0, result.surgeMultiplier)
+    }
+
+    @Test
+    fun estimateFareSuv() {
+        val result = service.estimateFare(
+            pickupLat = 12.9716,
+            pickupLng = 77.5946,
+            dropLat = 13.0827,
+            dropLng = 80.2707,
+            category = RideCategory.SUV
+        )
+        val expectedDuration = result.distanceInKm * 2
+        val expectedTotal = 100.0 + 20.0 * result.distanceInKm + 4.0 * expectedDuration
+        assertEquals(100.0, result.baseFare)
+        assertEquals(expectedDuration, result.durationInMin, 0.0001)
+        assertEquals(expectedTotal, result.totalFare, 0.01)
+        assertEquals(1.0, result.surgeMultiplier)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FareEstimatorService` with `estimateFare`
- define `RideCategory` enum and `FareEstimate` data class
- add unit tests verifying fare calculations

## Testing
- `gradle test --no-daemon` *(fails: Plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68500d591118832198d9bb53e8316004